### PR TITLE
change publish access to public

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,3 +22,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: 'public'


### PR DESCRIPTION
When you publish scoped packages to npm, it defaults to private access, but it is the intention to make this a public package.