### PR TITLE
normalize eslint

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -157,7 +157,7 @@ async function main () {
         }
 
         if (report) {
-          results = results.concat(report.results)
+          results = results.concat(report)
         }
       }
     })


### PR DESCRIPTION
Eslint changed their api, but we use the eslint version from the parent module, so we can't really depend on a specific version. This normalizes the api so that this packages usage aligns with the latest version, and we translate those calls in the case we import the old version.