### PR TITLE
Fixes issue using ESLint formatter

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -169,8 +169,8 @@ async function main () {
     const errorCount = results.map(r => r.errorCount).reduce((a, b) => a + b, 0)
 
     if (engine && errorCount > 0) {
-      const formatter = engine.loadFormatter()
-      const output = formatter(results)
+      const formatter = await engine.loadFormatter(undefined)
+      const output = formatter.format(results)
       if (output) {
         console.error(output)
       }


### PR DESCRIPTION
This got things working for our local setup (using all defaults), but it's possible that these changes are too tied to the default `ESLint` set up and do not provide the flexibility to pass in a custom engine (which appears to be an option.)   

---

When running with the `--lint` flag, we would receive the following
exception:

```
TypeError: formatter is not a function
    at main (.../node_modules/@ksmithut/prettier-standard/src/cli.js:180:22)
```

It seems like there may have been a few issues with changes to how
ESLint's formatter worked. This change resolves these issues allowing
the `--lint` flag to work with the default, provided `ESLint` formatting.

Fixes include:

- Adding an `await` to the `loadFormatter` call because
`eslint.loadFormatter` is an [async
function](https://github.com/eslint/eslint/blob/e233920857e282ba22116ad5f1dcc6dfabc8ef5b/docs/developer-guide/nodejs-api.md#-eslintloadformatternameorpath)

- Passing `undefined` to the `loadFormatter`; this allows us to use the
default ESLint formatter:

> undefined. In this case, loads the "stylish" built-in formatter.

- Update the call to `formatter` to use the returned `formatter` object,
and call the `format` function on it.

 The `loadFormatter` function returns a [`Formatter`
 object](https://github.com/eslint/eslint/blob/e233920857e282ba22116ad5f1dcc6dfabc8ef5b/docs/developer-guide/nodejs-api.md#-formatter-type).
 This `Formatter` object provides a `format` function. This changes the
 code to no longer expect `formatter` to be a function and instead
 expect the object.
